### PR TITLE
Consult fixes

### DIFF
--- a/consult-reftex-preview.el
+++ b/consult-reftex-preview.el
@@ -41,7 +41,7 @@
     (lambda (action cand)
       (if (or (not cand) (eq action 'return))
           (progn (funcall open)
-                 (mapc #'consult--kill-clean-buffer all-preview-buffers))
+                 (mapc #'kill-buffer all-preview-buffers))
         (catch 'exit 
           (let ((label (substring-no-properties (car cand)))
                 (file  (get-text-property 0 'reftex-file (car cand)))
@@ -57,7 +57,7 @@
                 (let ((preview-window (consult-reftex--window-preview marker type)))
                   (cl-pushnew (window-buffer preview-window) all-preview-buffers)
                   (while (> (length all-preview-buffers) consult-preview-max-count)
-                    (consult--kill-clean-buffer (car (last all-preview-buffers)))
+                    (kill-buffer (car (last all-preview-buffers)))
                     (setq all-preview-buffers (nbutlast all-preview-buffers))))
               (message "Label %s not found" label))))))))
 

--- a/consult-reftex-preview.el
+++ b/consult-reftex-preview.el
@@ -17,9 +17,9 @@
   "Create preview function for reftex labels."
   (let ((preview (consult--jump-preview))
         (open    (consult--temporary-files)))
-    (lambda (cand restore)
+    (lambda (action cand)
       (when cand 
-        (if restore
+        (if (eq action 'return)
             (progn (funcall preview nil t)
                    (funcall open))
           (catch 'exit 
@@ -38,8 +38,8 @@
 (defun consult-reftex-make-window-preview ()
   (let* ((all-preview-buffers)
          (open (consult--temporary-files)))
-    (lambda (cand restore)
-      (if (or (not cand) restore)
+    (lambda (action cand)
+      (if (or (not cand) (eq action 'return))
           (progn (funcall open)
                  (mapc #'consult--kill-clean-buffer all-preview-buffers))
         (catch 'exit 

--- a/consult-reftex.el
+++ b/consult-reftex.el
@@ -69,11 +69,8 @@ With prefix arg PREFIX, rescan the document for references."
                              :sort nil
                              :prompt "Label (esftNn): "
                              :require-match t
-                             :preview-key (if (plist-member (alist-get #'consult-reftex-reference
-                                                                       consult--read-config)
-                                                            :preview-key)
-                                              (plist-get config :preview-key)
-                                            consult-preview-key)
+                             :preview-key (or (plist-get (consult--customize-get) :preview-key)
+                                              consult-preview-key)
                              :history 'consult-reftex--reference-history
                              :state  (funcall consult-reftex-preview-function)
                              :annotate #'consult-reftex--get-annotation)))))


### PR DESCRIPTION
Recent changes to internal api's of consult cause problem. `consult-read--config` was changed to `consult--customize-alist` which results in an error. The type of the state function also changed and `consult--kill-clean-buffer` is no longer available. This fixes these issues at least for me.

 This is a quick fix and I don't understand the code very well so please disregard it if you something else in store.