### PR TITLE
Fix prompt to follow style of others

### DIFF
--- a/consult-reftex.el
+++ b/consult-reftex.el
@@ -139,7 +139,7 @@ With prefix ARG rescan the document."
                                 ("\\autopageref{" . "}"))))
                 :sort nil
                 :default (concat "\\ref{" label "}")
-                :prompt "Reference:"
+                :prompt "Reference: "
                 :require-match t
                 ;; :category 'reftex-label
                 :annotate (lambda (cand)


### PR DESCRIPTION
This is a relatively minor fix, but the prompt needs a space at the end.